### PR TITLE
Fix compilation errors - add missing dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "pinocchio-pubkey",
  "pinocchio-system",
  "shank",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1821,7 +1822,10 @@ name = "myproject-client"
 version = "0.1.0"
 dependencies = [
  "borsh 1.5.5",
+ "num-derive",
+ "num-traits",
  "solana-program",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -7,3 +7,6 @@ edition = { workspace = true }
 [dependencies]
 borsh = {workspace = true }
 solana-program = { workspace = true }
+thiserror = { workspace = true }
+num-derive = "0.4"
+num-traits = "0.2"

--- a/clients/rust/src/generated/errors/mod.rs
+++ b/clients/rust/src/generated/errors/mod.rs
@@ -4,3 +4,7 @@
 //!
 //! <https://github.com/codama-idl/codama>
 //!
+
+pub(crate) mod myproject;
+
+pub use self::myproject::MyprojectError;

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
     "@codama/nodes-from-anchor": "^1.1.6",
     "@codama/renderers": "^1.0.14",
     "codama": "^1.2.6"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -16,3 +16,4 @@ pinocchio-log = { workspace = true }
 pinocchio-pubkey = { workspace = true }
 pinocchio-system = { workspace = true }
 shank = { workspace = true }
+thiserror = { workspace = true }


### PR DESCRIPTION
- Add thiserror dependency to program/Cargo.toml
- Add thiserror, num-derive, num-traits to clients/rust/Cargo.toml
- Fixes compilation errors for missing crates